### PR TITLE
Adjust camera clipping planes

### DIFF
--- a/Assets/Hatbor/Scenes/Main.unity
+++ b/Assets/Hatbor/Scenes/Main.unity
@@ -674,9 +674,9 @@ Camera:
     y: 0
     width: 1
     height: 1
-  near clip plane: 0.3
-  far clip plane: 1000
   field of view: 60
+  near clip plane: 0.03
+  far clip plane: 100
   orthographic: 0
   orthographic size: 5
   m_Depth: -1


### PR DESCRIPTION
- Changed camera clipping planes to be able to get 10 times closer because 30cm near clip plane was too far away.
- I just went zero configuration way because > 100m distance would be rarely used, but should this be configurable, perhaps through RenderConfig?